### PR TITLE
Update version bump action with new wordings

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -22,6 +22,9 @@ jobs:
           tag-prefix: v
           target-branch: main
           commit-message: 'Bump version to {{version}}'
+          patch-wording: 'fix:,docs:,patch:,style:,refractor:'
+          minor-wording: 'feat:'
+          major-wording: 'BREAKING CHANGE:,MAJOR:'
       - name: cat package.json
         run: cat package.json
       - name: Output Step


### PR DESCRIPTION
Added more specific wording required for the version bump workflow action to incentivize clearer commit messages and prevent version bumps when there have been no impactful changes to the codebase (eg. updating the GitHub workflow).