### PR TITLE
BaseManager should throw instead of console.error if module is invalid

### DIFF
--- a/src/moduleManagers/BaseManager.ts
+++ b/src/moduleManagers/BaseManager.ts
@@ -75,20 +75,10 @@ export default abstract class BaseManager<
     }
 
     private importModules(files: DirReadResult[]): M[] {
-        const modules: M[] = [];
-
-        for (const file of files) {
-            const res = require(file.path);
-
-            try {
-                const module = this.createModule(file, res);
-                modules.push(module);
-            } catch (error: any) {
-                this.logInitError(file.path, error.message);
-            }
-        }
-
-        return modules;
+        return files.map(file => {
+            const result = require(file.path);
+            return this.createModule(file, result);
+        });
     }
 
     /**
@@ -99,11 +89,6 @@ export default abstract class BaseManager<
         const amount = this.modules.length;
         console.log(`> Successfully initialized ${amount} module(s) from ${this.dir}`);
     };
-
-    private logInitError(filepath: string, message: string): void {
-        console.error(`> Failed to initialize ${filepath}`);
-        console.error(`\t${message}`);
-    }
 
     /**
      * Adds a listener on a specific client event(s).

--- a/test/mock/commands/invalid.js
+++ b/test/mock/commands/invalid.js
@@ -1,1 +1,0 @@
-exports.invalid = true;

--- a/test/mock/invalidModules/index.js
+++ b/test/mock/invalidModules/index.js
@@ -1,0 +1,1 @@
+export const execute = undefined;

--- a/test/moduleManagers/BaseManager.test.ts
+++ b/test/moduleManagers/BaseManager.test.ts
@@ -10,19 +10,18 @@ class DummyBaseManager extends BaseManager<any, any> {
 }
 
 const dirPath = path.join(__dirname, '../mock/commands');
-const createManager = (options?: any): DummyBaseManager => {
-    return new DummyBaseManager({} as any, dirPath, options);
+const createManager = (customDirPath?: string, options?: any): DummyBaseManager => {
+    return new DummyBaseManager({} as any, customDirPath ?? dirPath, options);
 };
 
 describe('Testing BaseManager', () => {
-    const logInitErrorSpy = jest.spyOn(DummyBaseManager.prototype as any, 'logInitError');
     const createModuleSpy = jest.spyOn(DummyBaseManager.prototype as any, 'createModule');
     const readDirSpy = jest.spyOn(DummyBaseManager.prototype as any, 'readDir');
 
     afterEach(() => jest.clearAllMocks());
 
     it('should set Custom params', () => {
-        const manager = createManager({ prefix: '!' });
+        const manager = createManager(dirPath, { prefix: '!' });
         //@ts-ignore
         expect(manager.prefix).toBe('!');
     });
@@ -38,29 +37,25 @@ describe('Testing BaseManager', () => {
         };
 
         expect(readDirSpy).toHaveBeenCalledTimes(2); // Reads subdirectories recursively
-        expect(res).toHaveLength(3);
+        expect(res).toHaveLength(2);
         find('ping.js', './ping.js');
-        find('invalid.js', './invalid.js');
         find('ban.js', './admin/ban.js');
     });
 
     describe('Testing importModules method', () => {
-        it('should call createModule method 3 times with correct params', () => {
+        it('should call createModule method 2 times with correct params', () => {
             createManager();
             const dirReadRes = readDirSpy.mock.results[0].value;
 
-            expect(createModuleSpy).toBeCalledTimes(3);
+            expect(createModuleSpy).toBeCalledTimes(2);
             expect(createModuleSpy).toBeCalledWith(dirReadRes[0], require(dirReadRes[0].path));
             expect(createModuleSpy).toBeCalledWith(dirReadRes[1], require(dirReadRes[1].path));
-            expect(createModuleSpy).toBeCalledWith(dirReadRes[2], require(dirReadRes[2].path));
         });
 
-        it('should call logInitError because of invalid module', () => {
-            createManager();
-            const dirReadRes = readDirSpy.mock.results[0].value;
-
-            expect(logInitErrorSpy).toBeCalledTimes(1);
-            expect(logInitErrorSpy).lastCalledWith(dirReadRes[1].path, 'Invalid module');
+        it('should throw because of invalid module', () => {
+            expect(
+                () => createManager(path.join(__dirname, '../mock/invalidModules'))
+            ).toThrowError();
         });
 
         it('should return correct data', () => {
@@ -71,17 +66,6 @@ describe('Testing BaseManager', () => {
             expect(manager.modules[0].execute).toBeInstanceOf(Function);
         });
     });
-
-    it('should log error if module is invalid', () => {
-        const logInitError = jest.fn(DummyBaseManager.prototype['logInitError']);
-        const filePath = path.join(dirPath, 'invalid.js');
-        const consoleSpy = jest.spyOn(console, 'error');
-        logInitError(filePath, 'Invalid module');
-
-        expect(consoleSpy).toHaveBeenCalledWith(`> Failed to initialize ${filePath}`);
-        expect(consoleSpy).toHaveBeenCalledWith('\tInvalid module');
-    });
-
 
     it('should log results after all modules have been initialized', () => {
         const consoleSpy = jest.spyOn(console, 'log');


### PR DESCRIPTION
Fixes #24

##  Changes

- Removed try/catch from `BaseManager.importModules`
- Simplified code in `BaseManager.importModules`
- Removed `BaseManager.logInitError`
- Updated unit tests for `BaseManager.importModules`
- Because this change broke some unit tests, fixed them to work again