### PR TITLE
Update prefix command code to allow per-guild prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,28 @@ client.login(process.env.TOKEN);
 
 The init method provides Botly the client and points to where the modules are located.
 
-| field                         | value          | description                                                       |
-| ----------------------------- | -------------- | ----------------------------------------------------------------- |
-| client                        | Discord.Client | the used discord.js client                                        |
-| prefix _(optional)_           | string         | the prefix to use for prefix commands                             |
-| eventsDir _(optional)_        | string         | the absolute path to the event module directory                   |
-| commandsDir _(optional)_      | string         | the absolute path to the slash command module directory           |
-| buttonsDir _(optional)_       | string         | the absolute path to the button interaction module directory      |
-| selectMenuDir _(optional)_    | string         | the absolute path to the select menu interaction module directory |
-| prefixCommandDir _(optional)_ | string         | the absolute path to the prefix command module directory          |
+| field                         | value              | description                                                                                                                         |
+| ----------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| client                        | Discord.Client     | the used discord.js client                                                                                                          |
+| prefix _(optional)_           | string \| function | the prefix to use for prefix commands<br/>optionally, this can be a function that returns a string to allow for  per-guild prefixes |
+| eventsDir _(optional)_        | string             | the absolute path to the event module directory                                                                                     |
+| commandsDir _(optional)_      | string             | the absolute path to the slash command module directory                                                                             |
+| buttonsDir _(optional)_       | string             | the absolute path to the button interaction module directory                                                                        |
+| selectMenuDir _(optional)_    | string             | the absolute path to the select menu interaction module directory                                                                   |
+| prefixCommandDir _(optional)_ | string             | the absolute path to the prefix command module directory                                                                            |
+
+If you want your bot to have different prefixes (for prefix commands)
+for different guilds, then you can give a function to the `prefix` field in init function.
+
+The function can be either synchronous or asynchronous, and must return a `string`.
+
+```ts
+botly.init({
+    client,
+    prefix: (message) => database.settings.getPrefix(message.guild.id),
+    prefixCommandDir: path.join(__dirname, './prefixCommands')
+});
+```
 
 ### BotlyModules
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Discord Botly is a Discord Bot framework that wraps the [Discord.js](https://git
 
 - [What is Discord Botly and why use it?](#what-is-discord-botly-and-why-use-it)
   - [What is the purpose of this framework?](#what-is-the-purpose-of-this-framework)
-  - [#How does it achieve those things?](#how-does-it-achieve-those-things)
+  - [How does it achieve those things?](#how-does-it-achieve-those-things)
 - [Usage](#usage)
   - [Initialization](#initialization)
   - [BotlyModules](#botlymodules)

--- a/src/init.ts
+++ b/src/init.ts
@@ -28,6 +28,6 @@ export function init(config: InitArgs) {
         slashCommandModuleManager = new SlashCommandModuleManager(client, commandsDir);
     if (selectMenuDir)
         new DynamicIdModuleManager(client, selectMenuDir);
-    if (prefixCommandDir && prefix && prefix.length)
+    if (prefixCommandDir && prefix)
         prefixCommandModuleManager = new PrefixCommandModuleManager(prefix, client, prefixCommandDir);
 }

--- a/src/moduleManagers/BaseManager.ts
+++ b/src/moduleManagers/BaseManager.ts
@@ -27,19 +27,7 @@ export default abstract class BaseManager<
     modules: M[];
     dir: string;
 
-    /**
-     * @param otherParams parameters that should be set before importing and initializing all modules
-     */
-    constructor(client: Client, dir: string, otherParams?: { [key: string]: string; }) {
-        // Sets properties used by subclass (such as `prefix`)
-        // before modules are imported and initialized
-        if (otherParams) Object
-            .keys(otherParams)
-            .forEach(param =>
-                // @ts-expect-error
-                this[param] = otherParams[param]
-            );
-
+    constructor(client: Client, dir: string) {
         const files = this.readDir(dir);
         const modules = this.importModules(files);
 

--- a/src/moduleManagers/PrefixCommandModuleManager.ts
+++ b/src/moduleManagers/PrefixCommandModuleManager.ts
@@ -1,24 +1,26 @@
 import PrefixCommandModule from '../modules/PrefixCommandModule';
 import BaseManager from './BaseManager';
 import type { Client, Message } from 'discord.js';
-import type { BotlyModule, PrefixCommandData } from '../../typings';
+import type { BotlyModule, Prefix, PrefixCommandData } from '../../typings';
 
 export default class PrefixCommandModuleManager extends BaseManager<Message, PrefixCommandModule> {
-    prefix!: string;
+    prefix: Prefix;
 
-    constructor(prefix: string, client: Client, dir: string) {
-        super(client, dir, { prefix });
+    constructor(prefix: Prefix, client: Client, dir: string) {
+        super(client, dir);
+        this.prefix = prefix;
     }
 
     addListener(): void {
-        this.client.on('messageCreate', message => {
-            const module = this.modules.find(module => module.matches(message));
+        this.client.on('messageCreate', async message => {
+            const prefix = await this.getPrefix(message);
+            const module = this.modules.find(module => module.matches(message, prefix));
             if (module) module.listener(message);
         });
     }
 
     createModule(filename: string, module: BotlyModule<Message>): PrefixCommandModule {
-        return new PrefixCommandModule(this.prefix, filename, module);
+        return new PrefixCommandModule(filename, module);
     }
 
     get commandData(): PrefixCommandData[] {
@@ -28,5 +30,11 @@ export default class PrefixCommandModuleManager extends BaseManager<Message, Pre
             syntax: module.syntax,
             category: module.category,
         }));
+    }
+
+    private async getPrefix(message: Message): Promise<string> {
+        if (typeof this.prefix === 'string')
+            return this.prefix;
+        else return this.prefix(message);
     }
 }

--- a/src/modules/BaseModule.ts
+++ b/src/modules/BaseModule.ts
@@ -68,5 +68,5 @@ export default abstract class BaseModule<
      * @example
      * const module = modules.find(module => module.matches(...args));
      */
-    abstract matches(param: T): boolean;
+    abstract matches(param: T, ...args: unknown[]): boolean;
 }

--- a/src/modules/PrefixCommandModule.ts
+++ b/src/modules/PrefixCommandModule.ts
@@ -3,15 +3,13 @@ import type { Message } from 'discord.js';
 import type { BotlyModule } from '../../typings';
 
 export default class PrefixCommandModule extends BaseModule<Message> {
-    readonly prefix: string;
     readonly description?: string;
     readonly category?: string;
     readonly syntax?: string;
 
-    constructor(prefix: string, filename: string, file: BotlyModule<Message>) {
+    constructor(filename: string, file: BotlyModule<Message>) {
         super(filename, file);
 
-        this.prefix = prefix;
         this.description = file.description;
         this.category = file.category;
         this.syntax = file.syntax;
@@ -20,11 +18,9 @@ export default class PrefixCommandModule extends BaseModule<Message> {
     }
 
     async listener(message: Message): Promise<void> {
-        const parts = message.content
+        const args = message.content
             .trim()
-            .substring(this.prefix.length)
-            .split(' ');
-        const args = parts
+            .split(' ')
             .slice(1)
             .filter(s => !!s.length);
 
@@ -33,11 +29,11 @@ export default class PrefixCommandModule extends BaseModule<Message> {
         else this.callFilterCallbackIfExists(message, args);
     }
 
-    matches(message: Message): boolean {
+    matches(message: Message, prefix: string): boolean {
         const first = message.content.trimStart().split(' ')[0];
 
-        const hasPrefix = first.startsWith(this.prefix);
-        const isCommand = first.substring(this.prefix.length) === this.filenameWithoutExt;
+        const hasPrefix = first.startsWith(prefix);
+        const isCommand = first.substring(prefix.length) === this.filenameWithoutExt;
 
         if (!hasPrefix) return false;
         if (!isCommand) return false;

--- a/test/moduleManagers/BaseManager.test.ts
+++ b/test/moduleManagers/BaseManager.test.ts
@@ -10,8 +10,8 @@ class DummyBaseManager extends BaseManager<any, any> {
 }
 
 const dirPath = path.join(__dirname, '../mock/commands');
-const createManager = (customDirPath?: string, options?: any): DummyBaseManager => {
-    return new DummyBaseManager({} as any, customDirPath ?? dirPath, options);
+const createManager = (customDirPath?: string): DummyBaseManager => {
+    return new DummyBaseManager({} as any, customDirPath ?? dirPath);
 };
 
 describe('Testing BaseManager', () => {
@@ -19,12 +19,6 @@ describe('Testing BaseManager', () => {
     const readDirSpy = jest.spyOn(DummyBaseManager.prototype as any, 'readDir');
 
     afterEach(() => jest.clearAllMocks());
-
-    it('should set Custom params', () => {
-        const manager = createManager(dirPath, { prefix: '!' });
-        //@ts-ignore
-        expect(manager.prefix).toBe('!');
-    });
 
     it('should get all javascript files from the mock directory', () => {
         createManager();

--- a/test/modules/PrefixCommandModule.test.ts
+++ b/test/modules/PrefixCommandModule.test.ts
@@ -2,18 +2,10 @@ import PrefixCommandModule from '../../src/modules/PrefixCommandModule';
 import type { BotlyModule } from '../../typings';
 
 describe('Testing PrefixCommandModule', () => {
-    it('should create prefix parameter', () => {
-        const module = new PrefixCommandModule('!', 'test.js', {
-            execute: () => { },
-        });
-
-        expect(module.prefix).toBe('!');
-    });
-
     describe('Testing listener method', () => {
         it('should call execute method with correct args', async () => {
             const execute = jest.fn();
-            const module = new PrefixCommandModule('!', 'test.js', {
+            const module = new PrefixCommandModule('test.js', {
                 execute,
             });
 
@@ -24,7 +16,7 @@ describe('Testing PrefixCommandModule', () => {
 
         it('should call filterCallback method with correct args', async () => {
             const filterCallback = jest.fn();
-            const module = new PrefixCommandModule('!', 'test.js', {
+            const module = new PrefixCommandModule('test.js', {
                 execute: () => { },
                 filter: () => false,
                 filterCallback,
@@ -38,20 +30,20 @@ describe('Testing PrefixCommandModule', () => {
 
     describe('testing matches method', () => {
         it('should return true', () => {
-            const module1 = new PrefixCommandModule('!', 'test.js', {
+            const module1 = new PrefixCommandModule('test.js', {
                 execute: () => { },
             });
 
-            expect(module1.matches({ content: '!test' } as any)).toBe(true);
+            expect(module1.matches({ content: '!test' } as any, '!')).toBe(true);
         });
 
         it('should return false', () => {
-            const module1 = new PrefixCommandModule('!', 'test.js', {
+            const module1 = new PrefixCommandModule('test.js', {
                 execute: () => { },
             });
 
-            expect(module1.matches({ content: 'test' } as any)).toBe(false);
-            expect(module1.matches({ content: '!invalid' } as any)).toBe(false);
+            expect(module1.matches({ content: 'test' } as any, '!')).toBe(false);
+            expect(module1.matches({ content: '!invalid' } as any, '!')).toBe(false);
         });
     })
 
@@ -67,17 +59,17 @@ describe('Testing PrefixCommandModule', () => {
         const invalidCategory = { execute, category: 0 } as unknown as BotlyModule<any>;
 
         it('should not throw', () => {
-            expect(() => new PrefixCommandModule('!', 'someName.js', validDescription)).not.toThrowError();
-            expect(() => new PrefixCommandModule('!', 'someName.js', validSyntax)).not.toThrowError();
-            expect(() => new PrefixCommandModule('!', 'someName.js', validCategory)).not.toThrowError();
+            expect(() => new PrefixCommandModule('someName.js', validDescription)).not.toThrowError();
+            expect(() => new PrefixCommandModule('someName.js', validSyntax)).not.toThrowError();
+            expect(() => new PrefixCommandModule('someName.js', validCategory)).not.toThrowError();
         });
 
         it('should throw error', () => {
             expect(() =>
-                new PrefixCommandModule('!', 'someName.js', invalidDescription)
+                new PrefixCommandModule('someName.js', invalidDescription)
             ).toThrowError();
-            expect(() => new PrefixCommandModule('!', 'someName.js', invalidSyntax)).toThrowError();
-            expect(() => new PrefixCommandModule('!', 'someName.js', invalidCategory)).toThrowError();
+            expect(() => new PrefixCommandModule('someName.js', invalidSyntax)).toThrowError();
+            expect(() => new PrefixCommandModule('someName.js', invalidCategory)).toThrowError();
         });
     });
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,6 +29,8 @@ export default {
     registerGlobalSlashCommands,
 }
 
+export type Prefix = string | ((message: Message) => Promise<string> | string)
+
 export interface InitArgs {
     /**
      * The Discord client
@@ -37,8 +39,11 @@ export interface InitArgs {
     /**
      * The prefix used for prefix commands.
      * @example "!"
+     * @example ```ts
+     * (guild) => database.settings.getPrefix(guild.id)
+     * ```
      */
-    prefix?: string;
+    prefix?: Prefix;
     /**
      * Absolute path to the Client event directory
      */


### PR DESCRIPTION
# Changes

- Updated type for init command prefix field so that it accepts either string or function
- Updated unit-tests to match new code
- Updated README

Also took the opportunity to refactor and remove bad code.