### PR TITLE
Add optioanl aliases for prefix commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,15 +181,16 @@ For more detailed samples see [code-samples.md](code-samples.md)
 
 Discord Botly searches for specific `exports` in the BotlyModule files:
 
-| export name    | type                           | module type    | required | description                                                                                          |
-| -------------- | ------------------------------ | -------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| execute        | function                       | *              | true     | can run any code, for example, replies 'pong' for '/ping' command                                    |
-| filter         | function                       | *              | false    | checks wether execute can be called, returns a `boolean`                                             |
-| filterCallback | function                       | *              | false    | called when the `filter` function fails                                                              |
-| commandData    | instanceof SlashCommandBuilder | slash command  | true     | the slash command data, use [@discordjs/builders](https://www.npmjs.com/package/@discordjs/builders) |
-| description    | string                         | prefix command | false    | a description of the prefix command, used for [prefixCommandData](#prefix-command-data)              |
-| syntax         | string                         | prefix command | false    | the syntax for the prefix command, used for [prefixCommandData](#prefix-command-data)                |
-| category       | string                         | prefix command | false    | what category the prefix command is in, used for [prefixCommandData](#prefix-command-data)           |
+| export name    | type                           | module type    | required | description                                                                                                            |
+| -------------- | ------------------------------ | -------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| execute        | function                       | *              | true     | can run any code, for example, replies 'pong' for '/ping' command                                                      |
+| filter         | function                       | *              | false    | checks wether execute can be called, returns a `boolean`                                                               |
+| filterCallback | function                       | *              | false    | called when the `filter` function fails                                                                                |
+| commandData    | instanceof SlashCommandBuilder | slash command  | true     | the slash command data, use [@discordjs/builders](https://www.npmjs.com/package/@discordjs/builders)                   |
+| description    | string                         | prefix command | false    | a description of the prefix command, used for [prefixCommandData](#prefix-command-data)                                |
+| syntax         | string                         | prefix command | false    | the syntax for the prefix command, used for [prefixCommandData](#prefix-command-data)                                  |
+| category       | string                         | prefix command | false    | what category the prefix command is in, used for [prefixCommandData](#prefix-command-data)                             |
+| aliases        | string[]                       | prefix command | false    | aliases for the command (eg. `!balance` command may have an alias of `!bal`) [prefixCommandData](#prefix-command-data) |
 
 #### Callback Parameters
 
@@ -283,14 +284,14 @@ import { prefixCommandData } from 'discord-botly'
 console.log(prefixCommandData())
 /*
     Logs: [
-        { name: 'help', description: 'See available commands', syntax: 'help', category: undefined },
-        { name: 'ban', description: 'Ban a member', syntax: 'ban @member', category: 'admin' },
-        { name: 'coin', description: 'Toss a coin', syntax: 'coin', category: 'games' },
+        { name: 'help', description: 'See available commands', syntax: 'help', category: undefined, aliases: ['h'] },
+        { name: 'ban', description: 'Ban a member', syntax: 'ban @member', category: 'admin', aliases: [] },
+        { name: 'coin', description: 'Toss a coin', syntax: 'coin', category: 'games', aliases: ['c'] },
     ]
 */
 ```
 
-The `name`, `description`, `syntax` and `category` are automatically
+The `name`, `description`, `syntax`, `category` and `aliases` are automatically
 gathered from the prefix command modules.
 
 The `name` comes from the filename, and the rest comes from exports.
@@ -306,10 +307,12 @@ export const {
     category,
     description,
     syntax,
+    aliases,
 }: BotlyModule<Message> = {
     description: 'Replies with a greeting',
     syntax: '!hello <name>',
     category: 'games',
+    aliases: ['c'],
     execute: message => message.reply(Math.random() > 0.5 ? 'You got tails!' : 'You got heads!'),
 }
 ```

--- a/code-samples.md
+++ b/code-samples.md
@@ -42,7 +42,17 @@ export const { commandData, execute }: BotlyModule<CommandInteraction> = {
 import type { Message } from 'discord.js'
 import type { BotlyModule } from 'discord-botly'
 
-export const { execute }: BotlyModule<Message> = {
+export const {
+    execute,
+    description, // optional
+    syntax,      // optional
+    category,    // optional
+    aliases      // optional
+}: BotlyModule<Message> = {
+    description: 'See all available commands', // optional
+    syntax: 'help <category>',                 // optional
+    category: 'general',                       // optional
+    aliases: ['h'],                            // optional
     async execute(message, args) {
         const name = args[0]
         if (!name) await message.reply('Please mention a name!');
@@ -127,7 +137,8 @@ import { BotlyModule, PrefixCommandData, prefixCommandData } from 'discord-botly
 function commandToDescription(command: PrefixCommandData): string {
     const descriptionStr = command.description ? ` - ${command.description}` : ''
     const syntaxStr = command.syntax ? ` - ${command.syntax}` : ''
-    return `**${command.name}**${descriptionStr}${syntaxStr}`
+    const aliasesStr = command.aliases.length ? `\naliases: ${command.aliases.join(', ')}` : ''
+    return `**${command.name}**${descriptionStr}${syntaxStr}${aliasesStr}`
 }
 
 export const { execute, description, syntax }: BotlyModule<Message> = {

--- a/src/moduleManagers/PrefixCommandModuleManager.ts
+++ b/src/moduleManagers/PrefixCommandModuleManager.ts
@@ -29,6 +29,7 @@ export default class PrefixCommandModuleManager extends BaseManager<Message, Pre
             description: module.description,
             syntax: module.syntax,
             category: module.category,
+            aliases: module.aliases,
         }));
     }
 

--- a/src/modules/PrefixCommandModule.ts
+++ b/src/modules/PrefixCommandModule.ts
@@ -6,6 +6,7 @@ export default class PrefixCommandModule extends BaseModule<Message> {
     readonly description?: string;
     readonly category?: string;
     readonly syntax?: string;
+    readonly aliases: string[];
 
     constructor(filename: string, file: BotlyModule<Message>) {
         super(filename, file);
@@ -13,6 +14,7 @@ export default class PrefixCommandModule extends BaseModule<Message> {
         this.description = file.description;
         this.category = file.category;
         this.syntax = file.syntax;
+        this.aliases = file.aliases ?? [];
 
         this.validateCommandData()
     }
@@ -31,9 +33,12 @@ export default class PrefixCommandModule extends BaseModule<Message> {
 
     matches(message: Message, prefix: string): boolean {
         const first = message.content.trimStart().split(' ')[0];
+        const cmd = first.trim().substring(prefix.length);
 
         const hasPrefix = first.startsWith(prefix);
-        const isCommand = first.substring(prefix.length) === this.filenameWithoutExt;
+        const isCommand =
+            cmd === this.filenameWithoutExt
+            || this.aliases.includes(cmd);
 
         if (!hasPrefix) return false;
         if (!isCommand) return false;

--- a/test/mock/prefixCommands/ping.js
+++ b/test/mock/prefixCommands/ping.js
@@ -1,4 +1,5 @@
 exports.description = 'Replies with `pong!`';
 exports.syntax = 'ping';
 exports.category = 'random';
+exports.aliases = ['p'];
 exports.execute = () => { };

--- a/test/moduleManagers/PrefixCommandModuleManager.test.ts
+++ b/test/moduleManagers/PrefixCommandModuleManager.test.ts
@@ -64,10 +64,10 @@ describe('Testing PrefixCommandModuleManager', () => {
         const manager = createManager();
 
         expect(manager.commandData).toContainEqual(
-            { name: 'ping', description: 'Replies with `pong!`', syntax: 'ping', category: 'random' },
+            { name: 'ping', description: 'Replies with `pong!`', syntax: 'ping', category: 'random', aliases: ['p'] },
         );
         expect(manager.commandData).toContainEqual(
-            { name: 'foo', description: undefined, syntax: undefined, category: undefined },
+            { name: 'foo', description: undefined, syntax: undefined, category: undefined, aliases: [] },
         );
     });
 

--- a/test/modules/PrefixCommandModule.test.ts
+++ b/test/modules/PrefixCommandModule.test.ts
@@ -31,10 +31,13 @@ describe('Testing PrefixCommandModule', () => {
     describe('testing matches method', () => {
         it('should return true', () => {
             const module1 = new PrefixCommandModule('test.js', {
+                aliases: ['tst', 't'],
                 execute: () => { },
             });
 
             expect(module1.matches({ content: '!test' } as any, '!')).toBe(true);
+            expect(module1.matches({ content: '!tst' } as any, '!')).toBe(true);
+            expect(module1.matches({ content: '!t' } as any, '!')).toBe(true);
         });
 
         it('should return false', () => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -111,10 +111,12 @@ interface PrefixCommandModule {
     description?: string;
     category?: string;
     syntax?: string;
+    aliases?: string[];
 }
 
 export interface PrefixCommandData extends PrefixCommandModule {
     name: string;
+    aliases: string[];
 }
 
 /**


### PR DESCRIPTION
# Changes

- Added option to add `aliases` to prefix commands
- Added aliases to `PrefixCommandData` interface
- Updated unit-tests
- Updated docs