### PR TITLE
feat: Add support for filter modules (#42)

### DIFF
--- a/code-samples.md
+++ b/code-samples.md
@@ -100,29 +100,18 @@ export const { execute }: BotlyModule<SelectMenuInteraction> = {
 ## Filters
 
 ```ts
-// prefixCommands/admin/ban.ts
+// prefixCommands/admin/__filter.ts
 
-import type { Message } from 'discord.js'
-import type { BotlyModule } from 'discord-botly'
+import { Message } from 'discord.js';
+import database from '../../database';
 
-export const { execute, filter, filterCallback }: BotlyModule<Message> = {
-    async filter(message) {
-        return (
-            !!message.guild &&
-            !!message.mentions.members &&
-            !!message.mentions.members.size &&
-            message.author.id === message.guild.ownerId
-        )
-    },
-
-    async filterCallback(message) {
-        await message.reply('You are not allowed to use this command')
-    },
-
-    async execute(message) {
-        const member = message.mentions.members!.first()!
-        member.ban()
+export default async function(message: Message): Promise<boolean> {
+    const { adminUsers } = await database.settings.getAdminUsers(message.guildId!);
+    if (!adminUsers.includes(message.author.id)) {
+        await message.reply('You do not have permission to use this command');
+        return false;
     }
+    else return true;
 }
 ```
 

--- a/src/moduleManagers/DynamicIdModuleManager.ts
+++ b/src/moduleManagers/DynamicIdModuleManager.ts
@@ -14,7 +14,7 @@ export default class DynamicIdModuleManager extends BaseManager<T, DynamicIdModu
         });
     }
 
-    createModule(filename: string, module: BotlyModule<T>): DynamicIdModule {
-        return new DynamicIdModule(filename, module);
+    createModule(filepath: string, module: BotlyModule<T>): DynamicIdModule {
+        return new DynamicIdModule(this, filepath, module);
     }
 }

--- a/src/moduleManagers/EventModuleManager.ts
+++ b/src/moduleManagers/EventModuleManager.ts
@@ -3,7 +3,7 @@ import BaseManager from './BaseManager';
 import type { ClientEvents } from 'discord.js';
 import type { BotlyModule, FuncParams } from '../../typings';
 
-export default class EventModuleManager<T extends keyof ClientEvents> extends BaseManager<T, EventModule<T>> {
+export default class EventModuleManager<T extends keyof ClientEvents = keyof ClientEvents> extends BaseManager<keyof ClientEvents, EventModule<T>> {
     addListener(): void {
         // Since each event module if for a different event,
         // loop through them and add listeners individually
@@ -14,7 +14,7 @@ export default class EventModuleManager<T extends keyof ClientEvents> extends Ba
         }
     }
 
-    createModule(filename: string, module: BotlyModule<T>): EventModule<T> {
-        return new EventModule(filename, module);
+    createModule(filepath: string, module: BotlyModule<T>): EventModule<T> {
+        return new EventModule(this, filepath, module);
     }
 }

--- a/src/moduleManagers/PrefixCommandModuleManager.ts
+++ b/src/moduleManagers/PrefixCommandModuleManager.ts
@@ -19,8 +19,8 @@ export default class PrefixCommandModuleManager extends BaseManager<Message, Pre
         });
     }
 
-    createModule(filename: string, module: BotlyModule<Message>): PrefixCommandModule {
-        return new PrefixCommandModule(filename, module);
+    createModule(filepath: string, module: BotlyModule<Message>): PrefixCommandModule {
+        return new PrefixCommandModule(this, filepath, module);
     }
 
     get commandData(): PrefixCommandData[] {

--- a/src/moduleManagers/SlashCommandModuleManager.ts
+++ b/src/moduleManagers/SlashCommandModuleManager.ts
@@ -14,8 +14,8 @@ export default class SlashCommandModuleManager extends BaseManager<CommandIntera
         });
     }
 
-    createModule(filename: string, module: BotlyModule<CommandInteraction>): SlashCommandModule {
-        return new SlashCommandModule(module.commandData, filename, module);
+    createModule(filepath: string, module: BotlyModule<CommandInteraction>): SlashCommandModule {
+        return new SlashCommandModule(this, module.commandData, filepath, module);
     }
 
     /**

--- a/src/modules/BaseModule.ts
+++ b/src/modules/BaseModule.ts
@@ -1,7 +1,19 @@
+import path from 'path';
+import type { ClientEvents } from 'discord.js';
 import type { BotlyModule, FuncParams, ModuleTypes } from '../../typings';
+import type DynamicIdModuleManager from '../moduleManagers/DynamicIdModuleManager';
+import type EventModuleManager from '../moduleManagers/EventModuleManager';
+import type PrefixCommandModuleManager from '../moduleManagers/PrefixCommandModuleManager';
+import type SlashCommandModuleManager from '../moduleManagers/SlashCommandModuleManager';
+
+type ManagerClassType = PrefixCommandModuleManager
+    | DynamicIdModuleManager
+    | SlashCommandModuleManager
+    | EventModuleManager<keyof ClientEvents>
 
 export default abstract class BaseModule<
     T extends ModuleTypes,
+    M extends ManagerClassType,
     P extends FuncParams<T> = FuncParams<T>>
 {
     // The args type is set as `any[]` rather than `FuncParams<T>`
@@ -9,19 +21,28 @@ export default abstract class BaseModule<
     // no idea why ¯\_(ツ)_/¯
     /* eslint-disable @typescript-eslint/no-explicit-any */
     protected readonly execute: (...args: any[]) => void;
+
+    // Will be removed in v2.0.0 in favor of filter modules
     protected readonly filter?: (...args: any[]) => Promise<boolean> | boolean;
     protected readonly filterCallback?: (...args: any[]) => void;
 
+    readonly filepath: string;
     readonly filename: string;
     readonly filenameWithoutExt: string;
 
-    constructor(filename: string, file: BotlyModule<T>) {
+    readonly manager: M;
+
+    constructor(manager: M, filepath: string, file: BotlyModule<T>) {
         this.execute = file.execute;
+
+        // Will be removed in v2.0.0 in favor of filter modules
         this.filter = file.filter;
         this.filterCallback = file.filterCallback;
 
-        this.filename = filename;
-        this.filenameWithoutExt = filename.split('.js')[0];
+        this.filepath = filepath;
+        this.filename = path.basename(filepath);
+        this.filenameWithoutExt = this.filename.split('.js')[0];
+        this.manager = manager;
 
         this.validate();
     }
@@ -40,10 +61,35 @@ export default abstract class BaseModule<
         else this.callFilterCallbackIfExists(...args);
     }
 
+    /**
+     * Check all of the filters for the ModuleManager
+     * and find the ones that are "on the way" to this module.
+     *
+     * Because a module may have multiple filters.
+     *
+     * eg. `prefixCommands/admin/ban.ts`
+     * may have the filters:
+     * - prefixCommands/__filter.ts
+     * - prefixCommands/admin/filter.ts
+     */
     protected async passesFilterIfExists(...args: P): Promise<boolean> {
-        if (!this.filter) return true;
-        if (await this.filter(...args)) return true;
-        return false;
+        const moduleDirpath = path.dirname(this.filepath);
+
+        for (const [filepath, filter] of this.manager.filters) {
+            const filterDirpath = path.dirname(filepath);
+            if (!moduleDirpath.includes(filterDirpath)) continue;
+
+            // @ts-expect-error - For some reason the type for filter is messed up, so it doesn't want to accept args.
+            const passesFilter = await filter(...args);
+
+            if (passesFilter) continue;
+            else return false;
+        }
+
+        // Will be removed in v2.0.0 in favor of filter modules
+        if (this.filter) return this.filter(...args);
+
+        return true;
     }
 
     protected async callFilterCallbackIfExists(...args: P): Promise<void> {
@@ -54,6 +100,8 @@ export default abstract class BaseModule<
     private validate(): void {
         if (typeof this.execute !== 'function')
             throw new Error(`${this.filename}: exports.execute must be a function`);
+
+        // Will be removed in v2.0.0 in favor of filter modules
         if (this.filter && typeof this.filter !== 'function')
             throw new Error(`${this.filename}: exports.filter must be undefined or a function`);
         if (this.filterCallback && typeof this.filterCallback !== 'function')

--- a/src/modules/DynamicIdModule.ts
+++ b/src/modules/DynamicIdModule.ts
@@ -1,21 +1,22 @@
 import BaseModule from './BaseModule';
 import type { ButtonInteraction, SelectMenuInteraction } from 'discord.js';
 import type { BotlyModule } from '../../typings';
+import type DynamicIdModuleManager from '../moduleManagers/DynamicIdModuleManager';
 
 const paramNameRegexp = /(?<=\[).+?(?=\])/g;
 const dynamicParamRegexp = /\[.+?\]/g;
 
 type T = ButtonInteraction | SelectMenuInteraction;
 
-export default class DynamicIdModule extends BaseModule<T> {
+export default class DynamicIdModule extends BaseModule<T, DynamicIdModuleManager> {
     id: string;
     regexp: RegExp;
     params: RegExpMatchArray | null;
 
-    constructor(filename: string, file: BotlyModule<T>) {
-        super(filename, file);
+    constructor(manager: DynamicIdModuleManager, filepath: string, file: BotlyModule<T>) {
+        super(manager, filepath, file);
 
-        this.id = filename.split('.js')[0];
+        this.id = this.filenameWithoutExt;
 
         const { regexp, params } = this.createRegexp();
 

--- a/src/modules/EventModule.ts
+++ b/src/modules/EventModule.ts
@@ -1,7 +1,8 @@
 import BaseModule from './BaseModule';
 import type { ClientEvents } from 'discord.js';
+import type EventModuleManager from '../moduleManagers/EventModuleManager';
 
-export default class EventModule<T extends keyof ClientEvents> extends BaseModule<T> {
+export default class EventModule<T extends keyof ClientEvents> extends BaseModule<T, EventModuleManager<keyof ClientEvents>> {
     matches(): boolean {
         // Since there can be only one event module per event,
         // no matching is required, so just return true.

--- a/src/modules/PrefixCommandModule.ts
+++ b/src/modules/PrefixCommandModule.ts
@@ -1,15 +1,16 @@
 import BaseModule from './BaseModule';
 import type { Message } from 'discord.js';
 import type { BotlyModule } from '../../typings';
+import type PrefixCommandModuleManager from '../moduleManagers/PrefixCommandModuleManager';
 
-export default class PrefixCommandModule extends BaseModule<Message> {
+export default class PrefixCommandModule extends BaseModule<Message, PrefixCommandModuleManager> {
     readonly description?: string;
     readonly category?: string;
     readonly syntax?: string;
     readonly aliases: string[];
 
-    constructor(filename: string, file: BotlyModule<Message>) {
-        super(filename, file);
+    constructor(manager: PrefixCommandModuleManager, filepath: string, file: BotlyModule<Message>) {
+        super(manager, filepath, file);
 
         this.description = file.description;
         this.category = file.category;

--- a/src/modules/SlashCommandModule.ts
+++ b/src/modules/SlashCommandModule.ts
@@ -1,12 +1,13 @@
 import BaseModule from './BaseModule';
 import type { CommandInteraction } from 'discord.js';
 import type { BotlyModule, CommandData } from '../../typings';
+import type SlashCommandModuleManager from '../moduleManagers/SlashCommandModuleManager';
 
-export default class SlashCommandModule extends BaseModule<CommandInteraction> {
+export default class SlashCommandModule extends BaseModule<CommandInteraction, SlashCommandModuleManager> {
     commandData: CommandData;
 
-    constructor(commandData: CommandData, filename: string, file: BotlyModule<CommandInteraction>) {
-        super(filename, file);
+    constructor(manager: SlashCommandModuleManager, commandData: CommandData, filepath: string, file: BotlyModule<CommandInteraction>) {
+        super(manager, filepath, file);
         this.commandData = commandData;
         this.validateCommandData();
     }

--- a/test/mock/commands/__filter.js
+++ b/test/mock/commands/__filter.js
@@ -1,0 +1,1 @@
+exports.default = function () { };

--- a/test/mock/commands/admin/__filter.js
+++ b/test/mock/commands/admin/__filter.js
@@ -1,0 +1,1 @@
+exports.default = () => { };

--- a/test/mock/dummyManager.ts
+++ b/test/mock/dummyManager.ts
@@ -1,0 +1,6 @@
+import { Collection } from 'discord.js';
+import type { FilterFunction } from '../../typings';
+
+export default {
+    filters: new Collection<string, FilterFunction<any>>()
+};

--- a/test/mock/invalidFilter/__filter.js
+++ b/test/mock/invalidFilter/__filter.js
@@ -1,0 +1,1 @@
+exports.default = 'invalid';

--- a/test/moduleManagers/BaseManager.test.ts
+++ b/test/moduleManagers/BaseManager.test.ts
@@ -25,21 +25,22 @@ describe('Testing BaseManager', () => {
         const res: any[] = readDirSpy.mock.results[0].value;
 
         expect(readDirSpy).toHaveBeenCalledTimes(1); // Reads subdirectories recursively
-        expect(res).toHaveLength(2);
+        expect(res).toHaveLength(4);
         expect(res.find(p => path.basename(p) == 'ping.js')).toBeTruthy();
         expect(res.find(p => path.basename(p) == 'ban.js')).toBeTruthy();
     });
 
     describe('Testing importModules method', () => {
+        afterEach(() => jest.clearAllMocks());
+
         it('should call createModule method 2 times with correct params', () => {
             createManager();
-            const dirReadRes = readDirSpy.mock.results[0].value;
-
-            console.log(dirReadRes);
+            const dirReadRes = readDirSpy.mock.results[0].value
+                .filter((res: string) => !path.basename(res).startsWith('__'));
 
             expect(createModuleSpy).toBeCalledTimes(2);
-            expect(createModuleSpy).toBeCalledWith(path.basename(dirReadRes[0]), require(dirReadRes[0]));
-            expect(createModuleSpy).toBeCalledWith(path.basename(dirReadRes[1]), require(dirReadRes[1]));
+            expect(createModuleSpy).toBeCalledWith(dirReadRes[0], require(dirReadRes[0]));
+            expect(createModuleSpy).toBeCalledWith(dirReadRes[1], require(dirReadRes[1]));
         });
 
         it('should throw because of invalid module', () => {
@@ -48,14 +49,42 @@ describe('Testing BaseManager', () => {
             ).toThrowError();
         });
 
-        it('should return correct data', () => {
+        it('should throw because of invalid filter', () => {
+            expect(
+                () => createManager(path.join(__dirname, '../mock/invalidFilter'))
+            ).toThrowError();
+        });
+
+        it('should add 2 modules to `this.modules`', () => {
             const manager = createManager();
             expect(manager.modules).toHaveLength(2);
             expect(manager.modules[0].commandData).toBeInstanceOf(Object);
             expect(manager.modules[0].commandData.name).toBe('ban');
             expect(manager.modules[0].execute).toBeInstanceOf(Function);
         });
+
+        it('should add 2 filters to `this.filters`', () => {
+            const manager = createManager();
+            expect(manager.filters.size).toBe(2);
+            expect(manager.filters.first()).toBeInstanceOf(Function);
+        });
     });
+
+    describe('Testing validateFilterModule method', () => {
+        const spy = jest.spyOn(DummyBaseManager.prototype as any, 'validateFilterModule');
+        const impl = spy.getMockImplementation()!;
+        const filepath = 'test';
+
+        it('should pass validation', () => {
+            const testFilter = { default: () => true };
+            expect(() => impl(filepath, testFilter)).not.toThrow();
+        });
+
+        it('should throw when validating', () => {
+            const testFilter = { default: null };
+            expect(() => impl(filepath, testFilter)).toThrowError();
+        });
+    })
 
     it('should log results after all modules have been initialized', () => {
         const consoleSpy = jest.spyOn(console, 'log');

--- a/test/modules/DynamicIdModule.test.ts
+++ b/test/modules/DynamicIdModule.test.ts
@@ -1,6 +1,10 @@
+import { ButtonInteraction } from 'discord.js';
 import DynamicIdModule from '../../src/modules/DynamicIdModule';
-import type { ButtonInteraction } from 'discord.js';
+import dummyManager from '../mock/dummyManager';
 import type { BotlyModule } from '../../typings/index';
+import type DynamicIdModuleManager from '../../src/moduleManagers/DynamicIdModuleManager';
+
+const dm = dummyManager as DynamicIdModuleManager;
 
 describe('Testing DynamicIdModule', () => {
     const moduleData: BotlyModule<ButtonInteraction> = {
@@ -20,16 +24,16 @@ describe('Testing DynamicIdModule', () => {
 
     describe('Testing matches method', () => {
         it('should return true', () => {
-            const module1 = new DynamicIdModule('test.js', moduleData);
-            const module2 = new DynamicIdModule('test-[id].js', moduleData);
+            const module1 = new DynamicIdModule(dm, 'test.js', moduleData);
+            const module2 = new DynamicIdModule(dm, 'test-[id].js', moduleData);
 
             expect(module1.matches({ customId: 'test' } as ButtonInteraction)).toBe(true);
             expect(module2.matches({ customId: 'test-1234' } as ButtonInteraction)).toBe(true);
         });
 
         it('should return false', () => {
-            const module1 = new DynamicIdModule('test.js', moduleData);
-            const module2 = new DynamicIdModule('test-[id].js', moduleData);
+            const module1 = new DynamicIdModule(dm, 'test.js', moduleData);
+            const module2 = new DynamicIdModule(dm, 'test-[id].js', moduleData);
 
             expect(module1.matches({ customId: 'invalid' } as ButtonInteraction)).toBe(false);
             expect(module2.matches({ customId: 'test' } as ButtonInteraction)).toBe(false);
@@ -39,7 +43,7 @@ describe('Testing DynamicIdModule', () => {
     describe('Testing listener method', () => {
         it('should call execute method', async () => {
             const callback = jest.fn();
-            const module = new DynamicIdModule('test.js', {
+            const module = new DynamicIdModule(dm, 'test.js', {
                 execute: callback,
             });
 
@@ -49,7 +53,7 @@ describe('Testing DynamicIdModule', () => {
 
         it('should call callFilterCallbackIfExists', async () => {
             const callback = jest.fn();
-            const module = new DynamicIdModule('test.js', {
+            const module = new DynamicIdModule(dm, 'test.js', {
                 execute: () => { },
                 filter: () => false,
                 filterCallback: callback,
@@ -63,17 +67,17 @@ describe('Testing DynamicIdModule', () => {
     describe('Testing validateId method', () => {
         it('should pass validation', () => {
             expect(
-                () => new DynamicIdModule('id-without-params.js', moduleData)
+                () => new DynamicIdModule(dm, 'id-without-params.js', moduleData)
             ).not.toThrow();
 
             expect(
-                () => new DynamicIdModule('id-with-params-[id].js', moduleData)
+                () => new DynamicIdModule(dm, 'id-with-params-[id].js', moduleData)
             ).not.toThrow();
         });
 
         it('should fail validation', () => {
             expect(
-                () => new DynamicIdModule('id-with-duplicate-params-[id]-[id].js', moduleData)
+                () => new DynamicIdModule(dm, 'id-with-duplicate-params-[id]-[id].js', moduleData)
             ).toThrow();
         });
     });

--- a/test/modules/EventModule.test.ts
+++ b/test/modules/EventModule.test.ts
@@ -1,8 +1,10 @@
+import EventModuleManager from '../../src/moduleManagers/EventModuleManager';
 import EventModule from '../../src/modules/EventModule';
+import dummyManager from '../mock/dummyManager'
 
 describe('Testing EventModule', () => {
     it('should return true when calling `matches`', () => {
-        const module = new EventModule('test.js', { execute: () => { } });
+        const module = new EventModule(dummyManager as EventModuleManager, 'test.js', { execute: () => { } });
         expect(module.matches()).toBe(true);
     });
 });

--- a/test/modules/PrefixCommandModule.test.ts
+++ b/test/modules/PrefixCommandModule.test.ts
@@ -1,11 +1,15 @@
 import PrefixCommandModule from '../../src/modules/PrefixCommandModule';
+import dummyManager from '../mock/dummyManager';
 import type { BotlyModule } from '../../typings';
+import type PrefixCommandModuleManager from '../../src/moduleManagers/PrefixCommandModuleManager';
+
+const dm = dummyManager as PrefixCommandModuleManager;
 
 describe('Testing PrefixCommandModule', () => {
     describe('Testing listener method', () => {
         it('should call execute method with correct args', async () => {
             const execute = jest.fn();
-            const module = new PrefixCommandModule('test.js', {
+            const module = new PrefixCommandModule(dm, 'test.js', {
                 execute,
             });
 
@@ -16,7 +20,7 @@ describe('Testing PrefixCommandModule', () => {
 
         it('should call filterCallback method with correct args', async () => {
             const filterCallback = jest.fn();
-            const module = new PrefixCommandModule('test.js', {
+            const module = new PrefixCommandModule(dm, 'test.js', {
                 execute: () => { },
                 filter: () => false,
                 filterCallback,
@@ -30,7 +34,7 @@ describe('Testing PrefixCommandModule', () => {
 
     describe('testing matches method', () => {
         it('should return true', () => {
-            const module1 = new PrefixCommandModule('test.js', {
+            const module1 = new PrefixCommandModule(dm, 'test.js', {
                 aliases: ['tst', 't'],
                 execute: () => { },
             });
@@ -41,7 +45,7 @@ describe('Testing PrefixCommandModule', () => {
         });
 
         it('should return false', () => {
-            const module1 = new PrefixCommandModule('test.js', {
+            const module1 = new PrefixCommandModule(dm, 'test.js', {
                 execute: () => { },
             });
 
@@ -62,17 +66,17 @@ describe('Testing PrefixCommandModule', () => {
         const invalidCategory = { execute, category: 0 } as unknown as BotlyModule<any>;
 
         it('should not throw', () => {
-            expect(() => new PrefixCommandModule('someName.js', validDescription)).not.toThrowError();
-            expect(() => new PrefixCommandModule('someName.js', validSyntax)).not.toThrowError();
-            expect(() => new PrefixCommandModule('someName.js', validCategory)).not.toThrowError();
+            expect(() => new PrefixCommandModule(dm, 'someName.js', validDescription)).not.toThrowError();
+            expect(() => new PrefixCommandModule(dm, 'someName.js', validSyntax)).not.toThrowError();
+            expect(() => new PrefixCommandModule(dm, 'someName.js', validCategory)).not.toThrowError();
         });
 
         it('should throw error', () => {
             expect(() =>
-                new PrefixCommandModule('someName.js', invalidDescription)
+                new PrefixCommandModule(dm, 'someName.js', invalidDescription)
             ).toThrowError();
-            expect(() => new PrefixCommandModule('someName.js', invalidSyntax)).toThrowError();
-            expect(() => new PrefixCommandModule('someName.js', invalidCategory)).toThrowError();
+            expect(() => new PrefixCommandModule(dm, 'someName.js', invalidSyntax)).toThrowError();
+            expect(() => new PrefixCommandModule(dm, 'someName.js', invalidCategory)).toThrowError();
         });
     });
 });

--- a/test/modules/SlashCommandModule.test.ts
+++ b/test/modules/SlashCommandModule.test.ts
@@ -1,5 +1,9 @@
 import SlashCommandModule from '../../src/modules/SlashCommandModule';
+import dummyManager from '../mock/dummyManager';
 import type { CommandData } from '../../typings';
+import type SlashCommandModuleManager from '../../src/moduleManagers/SlashCommandModuleManager';
+
+const dm = dummyManager as SlashCommandModuleManager;
 
 describe('Testing SlashCommandModule', () => {
     const commandData = {
@@ -12,19 +16,19 @@ describe('Testing SlashCommandModule', () => {
 
         it('should throw error if commandData is not an object', () => {
             expect(() => {
-                new SlashCommandModule('commandData' as any, 'test.js', file);
+                new SlashCommandModule(dm, 'commandData' as any, 'test.js', file);
             }).toThrow();
         });
 
         it('should pass', () => {
             expect(() => {
-                new SlashCommandModule(commandData, 'test.js', file);
+                new SlashCommandModule(dm, commandData, 'test.js', file);
             }).not.toThrow();
         });
     });
 
     describe('Testing matches method', () => {
-        const module = new SlashCommandModule(commandData, 'test.js', { commandData, execute: () => { } });
+        const module = new SlashCommandModule(dm, commandData, 'test.js', { commandData, execute: () => { } });
 
         it('should return true', () => {
             expect(module.matches({ commandName: 'test' } as any)).toBe(true);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -89,6 +89,8 @@ export type FuncParams<T extends ModuleTypes> =
 
 export type CommandData = SlashCommandBuilder | SlashCommandOptionsOnlyBuilder | SlashCommandSubcommandsOnlyBuilder | Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>
 
+export type FilterFunction<T extends ModuleTypes> = (...args: FuncParams<T>) => boolean | Promise<boolean>;
+
 /**
  * Module code structure
  */
@@ -99,7 +101,9 @@ export type BotlyModule<T extends ModuleTypes> =
 
 interface BotlyModuleCoreFunctions<T extends ModuleTypes> {
     execute: (...args: FuncParams<T>) => void;
+    /** @deprecated Will be removed in v2.0.0 in favor of filter modules (see README#filter-modules, [issue#42](https://github.com/Kurstch/discord-botly/issues/42)) */
     filter?: (...args: FuncParams<T>) => boolean | Promise<boolean>;
+    /** @deprecated Will be removed in v2.0.0 in favor of filter modules (see README#filter-modules, [issue#42](https://github.com/Kurstch/discord-botly/issues/42)) */
     filterCallback?: (...args: FuncParams<T>) => void;
 }
 


### PR DESCRIPTION
Fixes #42 

# Changes

- Added option to make filter modules (explained in #42)
- Accordingly updated unit-tests and docs

Currently, the new filter system works alongside the old one, so that developers can have time to conververt before v2.0.0