### PR TITLE
feat: Add support for catch modules (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Discord Botly is a Discord Bot framework that wraps the [Discord.js](https://git
     - Methods for registering slash commands (so you don't have to mess around with the Discord API)
     - For `ButtonInteraction` and `SelectMenuInteraction` you can use [Dynamic parameter ids](#dynamic-parameter-ids)
     - You can make [filter modules](#filter-modules), which are filters that automatically get applied to [Botly Modules](#botlymodules)
+    - You can make [catch modules](#catch-modules), which are functions that automatically catch all errors thrown from [Botly Modules](#botlymodules)
     - Prefix command data is automatically gathered into one constant so you don't have to write help command manually,
       see [prefixCommandData](#prefix-command-data)
 
@@ -48,6 +49,7 @@ The project code may look something like this:
 ```txt
 .
 |-commands
+|   |-__catch.ts
 |   |-ping.ts
 |   |-balance.ts
 |   └─admin
@@ -68,6 +70,7 @@ The project code may look something like this:
 |   └─give-[userId]-role.ts
 |
 |-prefixCommands
+|   |-__catch.ts
 |   |-__filter.ts
 |   |-ping.ts
 |   └─help.ts
@@ -299,6 +302,68 @@ The above example for `prefixCommands/admin/__filter.ts` would check whether
 the message author is an admin the guild and return true or false appropriately.
 This filter would be applied to all commands in the `admin` directory and
 any sub-directories.
+
+### Catch modules
+
+Catch modules allow you to easily handle errors for multiple [botly modules](#botlymodules)
+as well as [filter modules](#filter-modules).
+
+Just like with [filter modules](#filter-modules) catch modules are files with
+the name `__catch.(js/ts)` that export a default function.
+
+Whenever an error is thrown in any relevant [botly module](#botlymodules) or [filter module](#filter-modules),
+it gets sent to the catch module.
+
+```ts
+import UserInputError from '../errors/UserInputError'
+import type { CommandInteraction } from 'discord.js'
+import type { CatchFunction } from 'discord-botly'
+
+const catcher: CatchFunction<CommandInteraction> = async (error, interaction) => {
+    if (error instanceof UserInputError)
+        await interaction.reply({ ephemeral: true, content: error.message })
+    else {
+        await interaction.reply({ ephemeral: true, content: 'Oops, something has gone wrong...' })
+        console.error(error.message)
+    }
+}
+
+export default catcher
+```
+
+Catch modules get applied to the directory they are in and it's sub-directories
+(same as [filter modules](#filter-modules)).
+
+```txt
+commands
+    |-admin
+    |   | __catch.ts
+    |   |-ban.ts
+    |   └─kick.ts
+    |
+    |-__catch.ts
+    └─ping.ts
+```
+
+In the above example we have 2 catch modules:
+
+- `commands/__catch.ts`
+- `commands/admin/__catch.ts`
+
+`commands/__catch.ts` will catch all errors thrown in the `commands` directory
+and it's sub-directories. While `commands/admin/__catch.ts` will only catch
+errors in the `admin` directory.
+
+> IMPORTANT: You may encounter that sometimes an error is not caught.
+> This in **not** an issue with discord-botly, but rather a problem with Node.js.
+>
+> See how to avoid it in [code-samples](code-samples.md#making-sure-that-async-errors-can-be-caught)
+>
+> For more details, check out these articles:
+>
+> - [Why asynchronous exceptions are uncatchable with callbacks](https://bytearcher.com/articles/why-asynchronous-exceptions-are-uncatchable/)
+> - [Error handling with Async/Await in JS](https://blog.segersian.com/2019/04/17/error-handling-async-await/)
+> - [await vs return vs return await](https://jakearchibald.com/2017/await-vs-return-vs-return-await/)
 
 ### Utils
 

--- a/code-samples.md
+++ b/code-samples.md
@@ -115,6 +115,69 @@ export default async function(message: Message): Promise<boolean> {
 }
 ```
 
+## Catchers
+
+```ts
+// prefixCommands/__catch.ts
+
+import UserInputError from '../../errors/UserInputError'
+import type { Message } from 'discord.js'
+import type { CatchFunction } from 'discord-botly'
+
+const catcher: CatchFunction<Message> = async (error, message) => {
+    if (error instanceof UserInputError) {
+        await message.reply(error.message)
+    } else {
+        await message.reply('Oops, something has gone wrong...')
+        console.error(error)
+    }
+}
+
+export default catcher
+```
+
+### Making sure that async errors can be caught
+
+Due to an issue with Node.js, rejected promises cannot
+be caught if they are not returned or awaited.
+
+For more details, check out these articles:
+
+- [Why asynchronous exceptions are uncatchable with callbacks](https://bytearcher.com/articles/why-asynchronous-exceptions-are-uncatchable/)
+- [Error handling with Async/Await in JS](https://blog.segersian.com/2019/04/17/error-handling-async-await/)
+- [await vs return vs return await](https://jakearchibald.com/2017/await-vs-return-vs-return-await/)
+
+In these examples we call `message.reply({})` which throws an error
+as you cannot send an empty message.
+
+This applies to all [botly modules](README.md#botlymodules) and [filter modules](README.md#filter-modules)
+
+```ts
+// The errors thrown here will NOT be caught, because the promise is not returned or awaited
+
+export function execute(message: Message) {
+    message.reply({})
+}
+
+export async function execute(message: Message) {
+    message.reply({})
+}
+```
+
+```ts
+// The errors thrown here will be caught, because the promise is returned or awaited
+
+export const execute = (message: Message) => message.reply({})
+
+export function execute(message: Message) {
+    return message.reply({})
+}
+
+export async function execute(message: Message) {
+    await message.reply({})
+}
+```
+
 ## Using PrefixCommandData
 
 ```ts

--- a/src/moduleManagers/DynamicIdModuleManager.ts
+++ b/src/moduleManagers/DynamicIdModuleManager.ts
@@ -10,7 +10,7 @@ export default class DynamicIdModuleManager extends BaseManager<T, DynamicIdModu
         this.client.on('interactionCreate', interaction => {
             if (!interaction.isButton() && !interaction.isSelectMenu()) return;
             const module = this.modules.find(module => module.matches(interaction));
-            if (module) module.listener(interaction, module.getParams(interaction));
+            if (module) module.listener(interaction as ButtonInteraction, module.getParams(interaction));
         });
     }
 

--- a/src/moduleManagers/PrefixCommandModuleManager.ts
+++ b/src/moduleManagers/PrefixCommandModuleManager.ts
@@ -15,7 +15,15 @@ export default class PrefixCommandModuleManager extends BaseManager<Message, Pre
         this.client.on('messageCreate', async message => {
             const prefix = await this.getPrefix(message);
             const module = this.modules.find(module => module.matches(message, prefix));
-            if (module) module.listener(message);
+            if (module) {
+                const args = message.content
+                    .trim()
+                    .split(' ')
+                    .slice(1)
+                    .filter(s => !!s.length);
+
+                module.listener(message, args);
+            }
         });
     }
 

--- a/src/modules/DynamicIdModule.ts
+++ b/src/modules/DynamicIdModule.ts
@@ -49,12 +49,6 @@ export default class DynamicIdModule extends BaseModule<T, DynamicIdModuleManage
         return params;
     }
 
-    async listener(interaction: T, params: { [key: string]: string; }): Promise<void> {
-        if (await this.passesFilterIfExists(interaction as ButtonInteraction, params))
-            this.execute(interaction, params);
-        else this.callFilterCallbackIfExists(interaction as ButtonInteraction, params);
-    }
-
     private validateId(): void {
         if (this.params && new Set(this.params).size !== this.params.length)
             throw new Error(`${this.filename}: every parameter in id must have a unique name`);

--- a/src/modules/PrefixCommandModule.ts
+++ b/src/modules/PrefixCommandModule.ts
@@ -20,18 +20,6 @@ export default class PrefixCommandModule extends BaseModule<Message, PrefixComma
         this.validateCommandData();
     }
 
-    async listener(message: Message): Promise<void> {
-        const args = message.content
-            .trim()
-            .split(' ')
-            .slice(1)
-            .filter(s => !!s.length);
-
-        if (await this.passesFilterIfExists(message, args))
-            this.execute(message, args);
-        else this.callFilterCallbackIfExists(message, args);
-    }
-
     matches(message: Message, prefix: string): boolean {
         const first = message.content.trimStart().split(' ')[0];
         const cmd = first.trim().substring(prefix.length);

--- a/test/mock/commands/__catch.js
+++ b/test/mock/commands/__catch.js
@@ -1,0 +1,1 @@
+exports.default = function () { };

--- a/test/mock/commands/admin/__catch.js
+++ b/test/mock/commands/admin/__catch.js
@@ -1,0 +1,1 @@
+exports.default = function () { };

--- a/test/mock/dummyManager.ts
+++ b/test/mock/dummyManager.ts
@@ -1,6 +1,7 @@
 import { Collection } from 'discord.js';
-import type { FilterFunction } from '../../typings';
+import type { CatchFunction, FilterFunction } from '../../typings';
 
 export default {
-    filters: new Collection<string, FilterFunction<any>>()
+    filters: new Collection<string, FilterFunction<any>>(),
+    catchers: new Collection<string, CatchFunction<any>>()
 };

--- a/test/mock/invalidCatch/__catch.js
+++ b/test/mock/invalidCatch/__catch.js
@@ -1,0 +1,1 @@
+exports.default = undefined;

--- a/test/moduleManagers/BaseManager.test.ts
+++ b/test/moduleManagers/BaseManager.test.ts
@@ -25,7 +25,7 @@ describe('Testing BaseManager', () => {
         const res: any[] = readDirSpy.mock.results[0].value;
 
         expect(readDirSpy).toHaveBeenCalledTimes(1); // Reads subdirectories recursively
-        expect(res).toHaveLength(4);
+        expect(res).toHaveLength(6);
         expect(res.find(p => path.basename(p) == 'ping.js')).toBeTruthy();
         expect(res.find(p => path.basename(p) == 'ban.js')).toBeTruthy();
     });
@@ -68,10 +68,16 @@ describe('Testing BaseManager', () => {
             expect(manager.filters.size).toBe(2);
             expect(manager.filters.first()).toBeInstanceOf(Function);
         });
+
+        it('should add 2 catchers to `this.catchers`', () => {
+            const manager = createManager();
+            expect(manager.catchers.size).toBe(2);
+            expect(manager.catchers.first()).toBeInstanceOf(Function);
+        });
     });
 
-    describe('Testing validateFilterModule method', () => {
-        const spy = jest.spyOn(DummyBaseManager.prototype as any, 'validateFilterModule');
+    describe('Testing validateUtilModule method', () => {
+        const spy = jest.spyOn(DummyBaseManager.prototype as any, 'validateUtilModule');
         const impl = spy.getMockImplementation()!;
         const filepath = 'test';
 

--- a/test/moduleManagers/PrefixCommandModuleManager.test.ts
+++ b/test/moduleManagers/PrefixCommandModuleManager.test.ts
@@ -48,7 +48,7 @@ describe('Testing PrefixCommandModuleManager', () => {
         await callback(message)
 
         expect(listenerSpy).toHaveBeenCalledTimes(1);
-        expect(listenerSpy).toHaveBeenCalledWith(message);
+        expect(listenerSpy).toHaveBeenCalledWith(message, []);
     });
 
     it('should create module', () => {

--- a/test/modules/BaseModule.test.ts
+++ b/test/modules/BaseModule.test.ts
@@ -1,7 +1,9 @@
-import { Message } from 'discord.js';
+import { Collection, Message } from 'discord.js';
 import BaseModule from '../../src/modules/BaseModule';
 import dummyManager from '../mock/dummyManager';
 import type { BotlyModule, FuncParams, ModuleTypes } from '../../typings';
+import type BaseManager from '../../src/moduleManagers/BaseManager';
+import type PrefixCommandModule from '../../src/modules/PrefixCommandModule';
 
 // Because BaseModule is and abstract class, we can't test it directly.
 // Instead, we'll create a subclass and test that.
@@ -156,6 +158,36 @@ describe('Testing BaseModule', () => {
 
             await testModule.listener({} as any, ['']);
             expect(callback).toHaveBeenCalled();
+        });
+
+        describe('testing error catching', () => {
+            const catcher = jest.fn();
+            const error = new Error();
+            let testModule: DummyBaseModule<Message>;
+            const call = async () => await testModule.listener({} as Message, []);
+
+            beforeEach(() => {
+                jest.clearAllMocks();
+                const manager = { filters: new Collection(), catchers: new Collection() } as BaseManager<Message, PrefixCommandModule>;
+                testModule = new DummyBaseModule(manager, 'root/test.js', {
+                    execute: () => { throw error; }
+                });
+            });
+
+            it('should catch error', async () => {
+                testModule.manager.catchers.set('root/__catch.js', catcher);
+                await call();
+                expect(catcher).toBeCalledWith(error, {}, []);
+            });
+
+            it('should not catch error when there is a catcher', async () => {
+                testModule.manager.catchers.set('root/sub-dir/__catch.js', catcher);
+                await expect(call()).rejects.toThrowError(error);
+            });
+
+            it('should not catch error when there is not a catcher', async () => {
+                await expect(call()).rejects.toThrowError(error);
+            });
         });
     });
 });

--- a/test/modules/PrefixCommandModule.test.ts
+++ b/test/modules/PrefixCommandModule.test.ts
@@ -13,7 +13,7 @@ describe('Testing PrefixCommandModule', () => {
                 execute,
             });
 
-            await module.listener({ content: '!test 1234' } as any);
+            await module.listener({ content: '!test 1234' } as any, ['1234']);
             expect(execute).toHaveBeenCalled();
             expect(execute).toHaveBeenCalledWith({ content: '!test 1234' } as any, ['1234']);
         });
@@ -26,7 +26,7 @@ describe('Testing PrefixCommandModule', () => {
                 filterCallback,
             });
 
-            await module.listener({ content: '!test 1234' } as any);
+            await module.listener({ content: '!test 1234' } as any, ['1234']);
             expect(filterCallback).toHaveBeenCalled();
             expect(filterCallback).toHaveBeenCalledWith({ content: '!test 1234' } as any, ['1234']);
         })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -92,6 +92,12 @@ export type CommandData = SlashCommandBuilder | SlashCommandOptionsOnlyBuilder |
 export type FilterFunction<T extends ModuleTypes> = (...args: FuncParams<T>) => boolean | Promise<boolean>;
 
 /**
+ * Type for catch module's default exported function.
+ * For more info see see README#catch-modules, [issue#44](https://github.com/Kurstch/discord-botly/issues/44)
+ */
+export type CatchFunction<T extends ModuleTypes> = (error: Error, ...args: FuncParams<T>) => void | Promise<void>;
+
+/**
  * Module code structure
  */
 export type BotlyModule<T extends ModuleTypes> =


### PR DESCRIPTION
Fixes #44 

## Changes

- Removed `listener` method overrides in `PrefixCommandModule` and `DynamicIdModule` as the same code can be run in their respective Managers, and we don't have to deal with complicated method overrides.
- Added support for `__catch` modules. Works simmilar as `__filter` modules, the only difference being that it handles all thrown errors for modules in the same directory or sub-directories.
- Updated docs and unit-tests for catch modules.