### PR TITLE
refactor(type exports): change how typings are provided to the end-user

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.10.3",
   "description": "Discord bot framework",
   "main": "dist/index.js",
-  "types": "typings/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prepublish": "tsc",
     "test": "jest --silent",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,15 @@
-import BotlyClient from "./BotlyClient";
+// We do not export the Manager and Module classes as they are not intended to be initialized outside the library
+// We do not export all types as there are many types exclusively used internally
 
-export {
-    BotlyClient
-};
+// This is the main interface for initializing and interacting with discord-botly
+export { default as BotlyClient } from "./BotlyClient";
+
+// These are the main types that the end-user may need access to
+export type {
+    Prefix,
+    InitArgs,
+    BotlyModule,
+    CatchFunction,
+    FilterFunction,
+    PrefixCommandData,
+} from '../typings/index';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         "esModuleInterop": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "declaration": true
     },
     "include": ["./src/**/*"]
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,8 +1,5 @@
 import type {
-    Client,
-    Interaction,
     ClientEvents,
-    MessageReaction,
     ButtonInteraction,
     CommandInteraction,
     SelectMenuInteraction,
@@ -10,12 +7,6 @@ import type {
     ClientOptions
 } from 'discord.js';
 import type { SlashCommandBuilder, SlashCommandOptionsOnlyBuilder, SlashCommandSubcommandsOnlyBuilder } from '@discordjs/builders';
-
-import BotlyClient from '../src/BotlyClient';
-
-export {
-    BotlyClient
-};
 
 export type Prefix = string | ((message: Message) => Promise<string> | string)
 


### PR DESCRIPTION
## Changes

- Added declaration option to tsconfig.ts.
  This means that now the type declarations for classes are generated automatically, rather than having to manually write them.
- Changed types filepath from `types/index.d.ts` to `dist/index.d.ts` (auto generated by tsc)
- Added type exports to src/index.ts since this is now the main import point for the lilbrary